### PR TITLE
Handle spaces in editor command.

### DIFF
--- a/timeflow/cli.py
+++ b/timeflow/cli.py
@@ -12,13 +12,18 @@ def log(args):
     timeflow.write_to_log_file(args.message)
 
 
+def _call_editor(editor, filename):
+    editor = editor.split()
+    subprocess.call(editor + [timeflow.LOG_FILE])
+
+
 def edit(args):
     if args.editor:
-        subprocess.call([args.editor, timeflow.LOG_FILE])
+        _call_editor(args.editor, timeflow.LOG_FILE)
     else:
         subprocess.call(['echo', 'Trying to open $EDITOR'])
         if os.environ.get('EDITOR'):
-            subprocess.call([os.environ.get('EDITOR'), timeflow.LOG_FILE])
+            _call_editor(os.environ.get('EDITOR'), timeflow.LOG_FILE)
         else:
             subprocess.call([
                 "echo",


### PR DESCRIPTION
Sometimes you want to pass additional args to your editor in $EDITOR
(like when launching mvim with "-f" option to keep running in
foreground). Using it this way would produce a subprocess call like
this:

```
subprocess.call(['mvim -f', 'my_filename'])
```

and python would fail to find the command "mvim -f" because shell=False.

This commit changes it to produce:

```
subprocess.call(['mvim', '-f', 'my_filename'])
```
